### PR TITLE
Create .about.yml

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,0 +1,28 @@
+---
+project: 'Discovery: OASIS Market Research Tool'
+name: discovery
+github:
+- 18F/discovery
+description: Market research tool for the OASIS procurement vehicle, which serves
+  contracting specialists throughout the U.S. Federal Government.
+partners:
+- General Services Administration
+impact: 
+stage: beta
+milestones:
+- 'May 2014: Initial Discovery stage began for task order generator project'
+- 'June 2014: Project pivoted based on user interviews and Discovery stage began for
+  market research tool'
+- 'July 2014: Work on Alpha stage began for market research tool'
+- 'November 2014: Alpha work complete'
+- 'February 2015: Name changed from "Mirage" to "Discovery"'
+contact:
+- josh.ruihley@gsa.gov
+stack: Python, JavaScript
+team: josh, kaitlin, brethauer, shawn
+licenses:
+  mirage: Public Domain (CC0)
+links:
+- http://gsa.gov/oasis
+- https://discovery.gsa.gov
+status: 


### PR DESCRIPTION
As we scale out the [about.yml](https://github.com/18f/about_yml) standard on projects, we need to relocates the yml file for this project from [here](https://github.com/18F/data-private/blob/master/projects/mirage.yml) to the primary project repo.